### PR TITLE
Add write support to FlatExcelMapper

### DIFF
--- a/examples/flat-excel-mapper-example/logs/flat-excel-mapper-example.log
+++ b/examples/flat-excel-mapper-example/logs/flat-excel-mapper-example.log
@@ -3,3 +3,14 @@
 2026-05-22 07:49:26.734 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:23):   Student{order=1, name='Lorem', birthDate='18/07/2017', joinDate=2025-07-19, isGood=false}
 2026-05-22 07:49:26.734 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:23):   Student{order=2, name='Ipsum', birthDate='7/27/18', joinDate=2017-07-19, isGood=true}
 2026-05-22 07:49:26.734 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:23):   Student{order=3, name='Haha', birthDate='7/19/17', joinDate=2017-07-19, isGood=false}
+2026-05-25 23:46:11.413 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:23): Reading students from: files/students.xlsx
+2026-05-25 23:46:11.586 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:25): Found 3 student(s):
+2026-05-25 23:46:11.589 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:27):   Student{order=1, name='Lorem', birthDate='18/07/2017', joinDate=2025-07-19, isGood=false}
+2026-05-25 23:46:11.589 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:27):   Student{order=2, name='Ipsum', birthDate='7/27/18', joinDate=2017-07-19, isGood=true}
+2026-05-25 23:46:11.589 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:27):   Student{order=3, name='Haha', birthDate='7/19/17', joinDate=2017-07-19, isGood=false}
+2026-05-25 23:46:11.589 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:48): Writing 2 student(s) to: files/students_output.xlsx
+2026-05-25 23:46:11.638 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:50): Write complete.
+2026-05-25 23:46:11.638 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:53): Reading back from: files/students_output.xlsx
+2026-05-25 23:46:11.645 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:55): Read back 2 student(s):
+2026-05-25 23:46:11.645 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:57):   Student{order=10, name='Alice', birthDate='01/01/1990', joinDate=2023-09-01, isGood=true}
+2026-05-25 23:46:11.645 [main]   INFO  com.github.mrloyal.Main com.github.mrloyal.Main.main(Main.java:57):   Student{order=11, name='Bob', birthDate='15/06/1985', joinDate=2024-01-15, isGood=false}

--- a/examples/flat-excel-mapper-example/src/main/java/com/github/mrloyal/Main.java
+++ b/examples/flat-excel-mapper-example/src/main/java/com/github/mrloyal/Main.java
@@ -4,6 +4,9 @@ import com.github.mrloyal.flatexcelmapper.FlatExcelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Paths;
+import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.List;
 
 public class Main {
@@ -11,15 +14,46 @@ public class Main {
     private static final Logger logger = LoggerFactory.getLogger(Main.class);
 
     public static void main(String[] args) throws Exception {
-        String filePath = args.length > 0 ? args[0] : "files/students.xlsx";
+        String inputPath  = args.length > 0 ? args[0] : "files/students.xlsx";
+        String outputPath = args.length > 1 ? args[1] : "files/students_output.xlsx";
 
         FlatExcelMapper mapper = new FlatExcelMapper();
 
-        logger.info("Reading all students from: {}", filePath);
-        List<Student> students = mapper.read(filePath, 0, Student.class);
-
+        // --- Read from an existing file ---
+        logger.info("Reading students from: {}", inputPath);
+        List<Student> students = mapper.read(inputPath, 0, Student.class);
         logger.info("Found {} student(s):", students.size());
         for (Student s : students) {
+            logger.info("  {}", s);
+        }
+
+        // --- Build a list of new students to write ---
+        Student alice = new Student();
+        alice.setOrder(10);
+        alice.setName("Alice");
+        alice.setBirthDate("01/01/1990");
+        alice.setJoinDate(LocalDate.of(2023, 9, 1));
+        alice.setGood(true);
+
+        Student bob = new Student();
+        bob.setOrder(11);
+        bob.setName("Bob");
+        bob.setBirthDate("15/06/1985");
+        bob.setJoinDate(LocalDate.of(2024, 1, 15));
+        bob.setGood(false);
+
+        List<Student> newStudents = Arrays.asList(alice, bob);
+
+        // --- Write to a new file ---
+        logger.info("Writing {} student(s) to: {}", newStudents.size(), outputPath);
+        mapper.write(newStudents, Paths.get(outputPath));
+        logger.info("Write complete.");
+
+        // --- Read back to verify ---
+        logger.info("Reading back from: {}", outputPath);
+        List<Student> written = mapper.read(outputPath, 0, Student.class);
+        logger.info("Read back {} student(s):", written.size());
+        for (Student s : written) {
             logger.info("  {}", s);
         }
     }

--- a/src/main/java/com/github/mrloyal/flatexcelmapper/FlatExcelMapper.java
+++ b/src/main/java/com/github/mrloyal/flatexcelmapper/FlatExcelMapper.java
@@ -9,6 +9,7 @@ import com.github.mrloyal.flatexcelmapper.exception.EmptyCellException;
 import com.github.mrloyal.flatexcelmapper.exception.ExcelMapperException;
 import com.github.mrloyal.flatexcelmapper.exception.InvalidValueException;
 import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.xssf.usermodel.XSSFCell;
@@ -22,9 +23,11 @@ import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -247,6 +250,122 @@ public class FlatExcelMapper {
             throw new ExcelMapperException(e);
         }
 
+    }
+
+    public <T> void write(List<T> list, XSSFSheet sheet)
+            throws ExcelMapperException, DataTypeNotSupportedException {
+        if (list == null || list.isEmpty()) return;
+
+        Class<?> clazz = list.get(0).getClass();
+        if (!clazz.isAnnotationPresent(ExcelEntity.class)) {
+            throw new ExcelMapperException(
+                    new IllegalArgumentException("Class must be annotated with @ExcelEntity"));
+        }
+
+        int dataStartRow = clazz.getAnnotation(ExcelEntity.class).dataStartRow();
+
+        for (int i = 0; i < list.size(); i++) {
+            XSSFRow row = sheet.createRow(dataStartRow - 1 + i);
+            writeRow(list.get(i), row, sheet.getWorkbook());
+        }
+    }
+
+    public <T> void write(List<T> list, Path path)
+            throws ExcelMapperException, DataTypeNotSupportedException {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        IOException ioException = null;
+        try {
+            XSSFSheet sheet = workbook.createSheet();
+            write(list, sheet);
+            try (FileOutputStream fos = new FileOutputStream(path.toFile())) {
+                workbook.write(fos);
+            }
+        } catch (IOException e) {
+            ioException = e;
+        } finally {
+            try {
+                workbook.close();
+            } catch (IOException e) {
+                if (ioException == null) ioException = e;
+            }
+        }
+        if (ioException != null) {
+            throw new ExcelMapperException(ioException);
+        }
+    }
+
+    private <T> void writeRow(T obj, XSSFRow row, XSSFWorkbook workbook)
+            throws ExcelMapperException, DataTypeNotSupportedException {
+        for (Method method : obj.getClass().getDeclaredMethods()) {
+            if (!method.isAnnotationPresent(ExcelColumn.class)) continue;
+
+            int colIndex = CellReference.convertColStringToIndex(
+                    method.getAnnotation(ExcelColumn.class).name());
+            XSSFCell cell = row.createCell(colIndex);
+
+            try {
+                Object value = method.invoke(obj);
+                if (method.isAnnotationPresent(ExcelDate.class)) {
+                    writeDateCell(cell, value, method.getAnnotation(ExcelDate.class), workbook);
+                } else {
+                    writePrimitiveCell(cell, value);
+                }
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw new ExcelMapperException(e);
+            }
+        }
+    }
+
+    private void writePrimitiveCell(XSSFCell cell, Object value) throws DataTypeNotSupportedException {
+        if (value == null) {
+            cell.setBlank();
+            return;
+        }
+        String typeName = value.getClass().getName();
+        switch (typeName) {
+            case "java.lang.Integer":  cell.setCellValue((Integer) value);  break;
+            case "java.lang.Boolean":  cell.setCellValue((Boolean) value);  break;
+            case "java.lang.Byte":     cell.setCellValue((Byte) value);     break;
+            case "java.lang.String":   cell.setCellValue((String) value);   break;
+            default:
+                throw new DataTypeNotSupportedException(
+                        String.format("Type '%s' is not supported", typeName));
+        }
+    }
+
+    private void writeDateCell(XSSFCell cell, Object value, ExcelDate dateAnn, XSSFWorkbook workbook)
+            throws DataTypeNotSupportedException {
+        if (value == null) {
+            cell.setBlank();
+            return;
+        }
+        String pattern = dateAnn.format();
+        if (dateAnn.type() == DateSourceType.DATE) {
+            Date date;
+            if (value instanceof Date) {
+                date = (Date) value;
+            } else if (value instanceof LocalDate) {
+                date = Date.from(((LocalDate) value).atStartOfDay(ZoneId.systemDefault()).toInstant());
+            } else {
+                throw new DataTypeNotSupportedException(
+                        String.format("Type '%s' is not supported for date cell", value.getClass().getName()));
+            }
+            CellStyle style = workbook.createCellStyle();
+            style.setDataFormat(workbook.createDataFormat().getFormat(pattern));
+            cell.setCellStyle(style);
+            cell.setCellValue(date);
+        } else {
+            String formatted;
+            if (value instanceof Date) {
+                formatted = new SimpleDateFormat(pattern).format((Date) value);
+            } else if (value instanceof LocalDate) {
+                formatted = ((LocalDate) value).format(DateTimeFormatter.ofPattern(pattern));
+            } else {
+                throw new DataTypeNotSupportedException(
+                        String.format("Type '%s' is not supported for date cell", value.getClass().getName()));
+            }
+            cell.setCellValue(formatted);
+        }
     }
 
     private void throwEmptyCellException(XSSFCell cell) throws EmptyCellException{

--- a/src/test/java/com/github/mrloyal/FlatExcelMapperWriteTest.java
+++ b/src/test/java/com/github/mrloyal/FlatExcelMapperWriteTest.java
@@ -1,0 +1,217 @@
+package com.github.mrloyal;
+
+import com.github.mrloyal.flatexcelmapper.FlatExcelMapper;
+import com.github.mrloyal.flatexcelmapper.exception.ExcelMapperException;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.GregorianCalendar;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FlatExcelMapperWriteTest {
+
+    private FlatExcelMapper mapper;
+    private List<Student> students;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new FlatExcelMapper();
+        students = buildStudents();
+    }
+
+    private List<Student> buildStudents() {
+        Student s1 = new Student();
+        s1.setOrder(1);
+        s1.setName("Lorem");
+        s1.setBirthDate(new GregorianCalendar(2017, Calendar.JULY, 18).getTime());
+        s1.setJoinDate(LocalDate.of(2020, 3, 15));
+        s1.setGood(true);
+
+        Student s2 = new Student();
+        s2.setOrder(2);
+        s2.setName("Ipsum");
+        s2.setBirthDate(new GregorianCalendar(1995, Calendar.DECEMBER, 25).getTime());
+        s2.setJoinDate(LocalDate.of(2021, 6, 1));
+        s2.setGood(false);
+
+        return Arrays.asList(s1, s2);
+    }
+
+    @Test
+    void writeToSheetCreatesCorrectNumberOfRows() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet();
+        mapper.write(students, sheet);
+        // Student.dataStartRow = 5, so two students occupy rows 4 and 5 (0-indexed)
+        assertEquals(2, sheet.getPhysicalNumberOfRows());
+        workbook.close();
+    }
+
+    @Test
+    void writeToSheetRoundTrip() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet();
+        mapper.write(students, sheet);
+
+        Path tmp = Files.createTempFile("write_sheet_test", ".xlsx");
+        try {
+            try (FileOutputStream fos = new FileOutputStream(tmp.toFile())) {
+                workbook.write(fos);
+            }
+            workbook.close();
+
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertEquals(2, result.size());
+            assertStudent1(result.get(0));
+            assertStudent2(result.get(1));
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathRoundTrip() throws Exception {
+        Path tmp = Files.createTempFile("write_path_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertEquals(2, result.size());
+            assertStudent1(result.get(0));
+            assertStudent2(result.get(1));
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathPreservesIntField() throws Exception {
+        Path tmp = Files.createTempFile("write_int_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertEquals(1, result.get(0).getOrder());
+            assertEquals(2, result.get(1).getOrder());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathPreservesStringField() throws Exception {
+        Path tmp = Files.createTempFile("write_string_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertEquals("Lorem", result.get(0).getName());
+            assertEquals("Ipsum", result.get(1).getName());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathPreservesBooleanField() throws Exception {
+        Path tmp = Files.createTempFile("write_bool_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertTrue(result.get(0).isGood());
+            assertFalse(result.get(1).isGood());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathPreservesDateStringField() throws Exception {
+        Path tmp = Files.createTempFile("write_date_string_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+
+            Calendar cal = Calendar.getInstance();
+
+            cal.setTime(result.get(0).getBirthDate());
+            assertEquals(2017, cal.get(Calendar.YEAR));
+            assertEquals(Calendar.JULY, cal.get(Calendar.MONTH));
+            assertEquals(18, cal.get(Calendar.DAY_OF_MONTH));
+
+            cal.setTime(result.get(1).getBirthDate());
+            assertEquals(1995, cal.get(Calendar.YEAR));
+            assertEquals(Calendar.DECEMBER, cal.get(Calendar.MONTH));
+            assertEquals(25, cal.get(Calendar.DAY_OF_MONTH));
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeToPathPreservesLocalDateField() throws Exception {
+        Path tmp = Files.createTempFile("write_localdate_test", ".xlsx");
+        try {
+            mapper.write(students, tmp);
+            List<Student> result = mapper.read(tmp.toFile(), 0, Student.class);
+            assertEquals(LocalDate.of(2020, 3, 15), result.get(0).getJoinDate());
+            assertEquals(LocalDate.of(2021, 6, 1), result.get(1).getJoinDate());
+        } finally {
+            Files.deleteIfExists(tmp);
+        }
+    }
+
+    @Test
+    void writeEmptyListDoesNothing() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet();
+        mapper.write(Collections.emptyList(), sheet);
+        assertEquals(0, sheet.getPhysicalNumberOfRows());
+        workbook.close();
+    }
+
+    @Test
+    void writeThrowsForClassWithoutExcelEntityAnnotation() {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        XSSFSheet sheet = workbook.createSheet();
+        assertThrows(ExcelMapperException.class,
+                () -> mapper.write(Collections.singletonList(new UnannotatedEntity()), sheet));
+    }
+
+    private void assertStudent1(Student s) {
+        assertEquals(1, s.getOrder());
+        assertEquals("Lorem", s.getName());
+        assertTrue(s.isGood());
+        assertEquals(LocalDate.of(2020, 3, 15), s.getJoinDate());
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(s.getBirthDate());
+        assertEquals(2017, cal.get(Calendar.YEAR));
+        assertEquals(Calendar.JULY, cal.get(Calendar.MONTH));
+        assertEquals(18, cal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    private void assertStudent2(Student s) {
+        assertEquals(2, s.getOrder());
+        assertEquals("Ipsum", s.getName());
+        assertFalse(s.isGood());
+        assertEquals(LocalDate.of(2021, 6, 1), s.getJoinDate());
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(s.getBirthDate());
+        assertEquals(1995, cal.get(Calendar.YEAR));
+        assertEquals(Calendar.DECEMBER, cal.get(Calendar.MONTH));
+        assertEquals(25, cal.get(Calendar.DAY_OF_MONTH));
+    }
+
+    static class UnannotatedEntity {
+        public String getValue() { return "x"; }
+    }
+}


### PR DESCRIPTION
Implements write(List<T>, XSSFSheet) and write(List<T>, Path) methods that serialize annotated POJOs back to .xlsx files, mirroring the existing read API. Covers primitive types, String, and date fields (both DATE-formatted cells and STRING patterns). Updates the example app to demonstrate a full read → write → read-back round-trip and adds FlatExcelMapperWriteTest to verify the new functionality.